### PR TITLE
feat: [DI-22550] - Added logic to disable end date calendar dates which are before selected start date

### DIFF
--- a/packages/manager/src/components/DatePicker/DateTimePicker.tsx
+++ b/packages/manager/src/components/DatePicker/DateTimePicker.tsx
@@ -27,6 +27,8 @@ export interface DateTimePickerProps {
   format?: string;
   /** Label for the input field */
   label?: string;
+  /** Minimum date-time before which all date-time will be disabled */
+  minDate?: DateTime;
   /** Callback when the "Apply" button is clicked */
   onApply?: () => void;
   /** Callback when the "Cancel" button is clicked */
@@ -64,6 +66,7 @@ export const DateTimePicker = ({
   errorText = '',
   format = 'yyyy-MM-dd HH:mm',
   label = 'Select Date and Time',
+  minDate,
   onApply,
   onCancel,
   onChange,
@@ -219,6 +222,7 @@ export const DateTimePicker = ({
               borderRadius: `${theme.spacing(2)}`,
               borderWidth: '0px',
             })}
+            minDate={minDate}
           />
           <Grid
             container
@@ -228,6 +232,12 @@ export const DateTimePicker = ({
             {showTime && (
               <Grid item xs={4}>
                 <TimePicker
+                  minTime={
+                    minDate &&
+                    minDate.toISODate() === selectedDateTime?.toISODate()
+                      ? minDate
+                      : undefined
+                  }
                   slotProps={{
                     actionBar: {
                       sx: (theme: Theme) => ({

--- a/packages/manager/src/components/DatePicker/DateTimeRangePicker.tsx
+++ b/packages/manager/src/components/DatePicker/DateTimeRangePicker.tsx
@@ -9,6 +9,9 @@ import { DateTimePicker } from './DateTimePicker';
 import type { SxProps, Theme } from '@mui/material/styles';
 
 export interface DateTimeRangePickerProps {
+  /** If true, shows the date presets field instead of the date pickers */
+  enablePresets?: boolean;
+
   /** Properties for the end date field */
   endDateProps?: {
     /** Custom error message for invalid end date */
@@ -41,8 +44,6 @@ export interface DateTimeRangePickerProps {
   presetsProps?: {
     /** Default value for the presets field */
     defaultValue?: { label: string; value: string };
-    /** If true, shows the date presets field instead of the date pickers */
-    enablePresets?: boolean;
     /** Label for the presets field */
     label?: string;
     /** placeholder for the presets field */
@@ -70,16 +71,18 @@ export interface DateTimeRangePickerProps {
 }
 
 const presetsOptions = [
+  { label: 'Last 30 Minutes', value: '30minutes' },
+  { label: 'Last 12 Hours', value: '12hours' },
   { label: 'Last 24 Hours', value: '24hours' },
   { label: 'Last 7 Days', value: '7days' },
   { label: 'Last 30 Days', value: '30days' },
-  { label: 'This Month', value: 'this_month' },
-  { label: 'Last Month', value: 'last_month' },
   { label: 'Custom', value: 'custom_range' },
 ];
 
 export const DateTimeRangePicker = (props: DateTimeRangePickerProps) => {
   const {
+    enablePresets = false,
+
     endDateProps: {
       errorMessage: endDateErrorMessage = 'End date/time cannot be before the start date/time.',
       label: endLabel = 'End Date and Time',
@@ -93,8 +96,7 @@ export const DateTimeRangePicker = (props: DateTimeRangePickerProps) => {
     onChange,
 
     presetsProps: {
-      defaultValue: presetsDefaultValue = { label: '', value: '' },
-      enablePresets = false,
+      defaultValue: presetsDefaultValue = presetsOptions[0],
       label: presetsLabel = 'Time Range',
       placeholder: presetsPlaceholder = 'Select a preset',
     } = {},
@@ -152,29 +154,22 @@ export const DateTimeRangePicker = (props: DateTimeRangePickerProps) => {
   const handlePresetSelection = (value: string) => {
     const now = DateTime.now();
     let newStartDateTime: DateTime | null = null;
-    let newEndDateTime: DateTime | null = null;
-
+    let newEndDateTime: DateTime | null = now;
     switch (value) {
+      case '30minutes':
+        newStartDateTime = now.minus({ minutes: 30 });
+        break;
+      case '12hours':
+        newStartDateTime = now.minus({ hours: 12 });
+        break;
       case '24hours':
         newStartDateTime = now.minus({ hours: 24 });
-        newEndDateTime = now;
         break;
       case '7days':
         newStartDateTime = now.minus({ days: 7 });
-        newEndDateTime = now;
         break;
       case '30days':
         newStartDateTime = now.minus({ days: 30 });
-        newEndDateTime = now;
-        break;
-      case 'this_month':
-        newStartDateTime = now.startOf('month');
-        newEndDateTime = now.endOf('month');
-        break;
-      case 'last_month':
-        const lastMonth = now.minus({ months: 1 });
-        newStartDateTime = lastMonth.startOf('month');
-        newEndDateTime = lastMonth.endOf('month');
         break;
       case 'custom_range':
         newStartDateTime = null;
@@ -278,6 +273,7 @@ export const DateTimeRangePicker = (props: DateTimeRangePickerProps) => {
             errorText={endDateError ?? undefined}
             format={format}
             label={endLabel}
+            minDate={startDateTime || undefined}
             onChange={handleEndDateTimeChange}
             placeholder={endDatePlaceholder}
             showTimeZone={showEndTimeZone}


### PR DESCRIPTION
## Description 📝

Added a logic to disable the dates in the end date calendar which are before the selected start date

## Changes  🔄

List any change(s) relevant to the reviewer.

1. Added minDate prop to DateTimePicker
2. Added to select first presets options if no default value passed

## Target release date 🗓️
N.A



## Preview 📷

**Include a screenshot or screen recording of the change.**

:lock: Use the [Mask Sensitive Data](https://cloud.linode.com/profile/settings) setting for security.

:bulb: Use `<video src="" />` tag when including recordings in table.

![Screenshot 2024-12-19 at 6 23 04 PM](https://github.com/user-attachments/assets/91e5034b-fd8b-4386-97d4-1d866449b29d)
![Screenshot 2024-12-19 at 6 23 11 PM](https://github.com/user-attachments/assets/07a66d51-81fa-49cf-b569-6c5eb3ba3393)


## How to test 🧪

### Prerequisites

(How to setup test environment)

- ...
- ...

### Reproduction steps

(How to reproduce the issue, if applicable)

- [ ] ...
- [ ] ...

### Verification steps

(How to verify changes)

- [ ] ...
- [ ] ...

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [ ] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All unit tests are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>

